### PR TITLE
fix(android): support hardware keyboard text input

### DIFF
--- a/platform/Android/sweeteditor/src/main/java/com/qiplat/sweeteditor/SweetEditor.java
+++ b/platform/Android/sweeteditor/src/main/java/com/qiplat/sweeteditor/SweetEditor.java
@@ -381,9 +381,9 @@ public class SweetEditor extends View {
 
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        handleKeyEventFromIME(event);
+        boolean handled = handleKeyEventFromIME(event);
         refreshHoverActivation(event);
-        return true;
+        return handled || super.onKeyDown(keyCode, event);
     }
 
     @Override
@@ -2050,18 +2050,18 @@ public class SweetEditor extends View {
         }
     }
 
-    void handleKeyEventFromIME(KeyEvent event) {
+    boolean handleKeyEventFromIME(KeyEvent event) {
         long t0 = ENABLE_PERF_LOG ? System.nanoTime() : 0;
         // Inline suggestion keyboard interception (Tab/Escape)
         if (mInlineSuggestionController != null && mInlineSuggestionController.isShowing()) {
             if (mInlineSuggestionController.handleAndroidKeyCode(event.getKeyCode())) {
-                return;
+                return true;
             }
         }
         // Completion panel keyboard interception (Enter/Escape/Up/Down)
         if (mCompletionPopupController != null && mCompletionPopupController.isShowing()) {
             if (mCompletionPopupController.handleAndroidKeyCode(event.getKeyCode())) {
-                return;
+                return true;
             }
         }
         int nativeKeyCode = mapAndroidKeyCode(event.getKeyCode());
@@ -2082,7 +2082,7 @@ public class SweetEditor extends View {
                     resetCursorBlink();
                     flush();
                     logInputPerf(t0, "key-enter");
-                    return;
+                    return true;
                 }
             }
             if (nativeKeyCode == KeyCode.BACKSPACE) {
@@ -2100,7 +2100,7 @@ public class SweetEditor extends View {
                 flush();
                 updateInputConnectionSelectionState();
                 logInputPerf(t0, "key-cmd");
-                return;
+                return true;
             }
             dispatchKeyEventResult(result);
             if (wasComposing && !mEditorCore.isComposing()
@@ -2114,7 +2114,18 @@ public class SweetEditor extends View {
             flush();
             updateInputConnectionSelectionState();
             logInputPerf(t0, "key");
+            return true;
         }
+        if (!event.isCtrlPressed() && !event.isAltPressed() && !event.isMetaPressed()) {
+            int unicode = event.getUnicodeChar();
+            if (unicode > 0 && !Character.isISOControl(unicode)) {
+                insertText(new String(Character.toChars(unicode)));
+                updateInputConnectionSelectionState();
+                logInputPerf(t0, "key-text");
+                return true;
+            }
+        }
+        return false;
     }
 
     void logInputPerf(long startNanos, String tag) {


### PR DESCRIPTION
# Pull Request

## 提交前检查清单

- [x] 已阅读贡献指南 (docs/zh/join.md) 并遵循规范
- [x] 本地构建通过
- [ ] 单元测试通过 (如有)
- [x] 代码审查 (Self-review) 完成

---

## AI/Vibe Coding 声明 (必选)

- [ ] 无 AI 生成代码
- [ ] AI 辅助参考
- [x] 部分 AI 生成代码
- [ ] Vibe coding (完全由 AI 完成)

**使用的 AI 工具 (如有):**

Codex

---

## 变更分类 (必选其一)

- [ ] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `docs` 文档/模板
- [ ] `style` 代码格式 (不影响功能)
- [ ] `refactor` 重构 (既不修复 bug 也不添加功能)
- [ ] `perf` 性能优化
- [ ] `test` 测试相关
- [ ] `chore` 构建/CI/依赖/工具链
- [ ] `revert` 回滚
- [ ] `security` 安全修复

---

## 测试情况 (必选)

- [ ] 已完成单元测试 - 所有测试通过
- [ ] 已完成单元测试 - 部分测试通过 (需在下方说明原因)
- [x] 已完成手动测试
- [ ] 无需测试 (仅文档/注释等修改)
- [ ] 测试计划待补充

**测试覆盖的模块/功能:**

Android 硬件键盘输入
`SweetEditor.onKeyDown()`
`SweetEditor.handleKeyEventFromIME()`

**测试环境说明:**

Windows 10, Android Studio 2025, Android API 34, Scrcpy 3.3.4

---

## 影响范围 (可多选)

### 核心层 Core (C++)

- [ ] 文档模型 (Document)
- [ ] 布局引擎 (Layout)
- [ ] 装饰管理 (Decoration)
- [ ] 编辑核心 (EditorCore)
- [ ] 手势处理 (Gesture)
- [ ] C API 桥接 (c_api.h)
- [ ] 其他核心模块

### 平台适配层 Platform

- [x] Android 平台
- [ ] iOS/macOS 平台
- [ ] Windows 平台
- [ ] Swing 平台
- [ ] Web/Emscripten
- [ ] OHOS 平台
- [ ] 不涉及平台相关改动

### 基础设施 Infrastructure

- [ ] CI/CD 配置
- [ ] 构建脚本 (CMake/Gradle等)
- [ ] 第三方依赖 (3dparty/)

**平台同步检查关键点:**

- c_api.h 新增或修改函数
- TextEditResult / GestureResult / KeyEventResult / ScrollMetrics / LayoutMetrics 等结构变更
- 渲染模型字段变更
- IME、手势、折叠、装饰相关的核心行为变更

---

## 变更详情

### 摘要

修复 Android 端在 `scrcpy` 等场景下，无法正常输入字符到编辑器的问题。

### 动机/背景

当前 Android 输入链路主要覆盖了控制键映射，但缺少对硬件键盘普通字符事件的可靠兜底处理。

因此在 `scrcpy` 或外接键盘输入时，字母、数字、符号等可打印字符可能被事件链吞掉，无法作为文本正确进入编辑器。

### 具体改动

- 调整 `SweetEditor.onKeyDown()` 不再无条件消费所有按键事件
- 将 `handleKeyEventFromIME()` 从 `void` 改为 `boolean`
- 保留原有控制键处理逻辑
- 为未映射为编辑器命令键的硬件键盘输入新增可打印字符 fallback
- 在未按下 Ctrl / Alt / Meta 时，通过 `event.getUnicodeChar()` 获取可打印字符并直接插入文本
- 在文本插入后同步更新输入连接选区状态
- 使用 `Character.toChars(unicode)` 处理 Unicode 字符，避免简单强转 `char` 造成字符截断

### Breaking Changes

无

---

## 关联 Issue

无

## 自动化审查说明

**sourcery-ai 及其他 code review 工具请务必进行中英双语审查与交流。**

**Note: Please ensure sourcery-ai and other tools perform bilingual (Chinese & English) review.**

## Summary by Sourcery

Fix Android editor key handling to properly support hardware keyboard text input while preserving existing control key behavior.

Bug Fixes:
- Allow hardware keyboard printable characters on Android (including scrcpy scenarios) to be inserted into the editor instead of being swallowed by the key event pipeline.

Enhancements:
- Return a handled flag from Android IME key handling and fall back to the default View key handling when events are not consumed.